### PR TITLE
Restrict adding and removing likes to current_users

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -25,6 +25,7 @@ class LikesController < ApplicationController
   # POST /likes.json
   def create
     @like = Like.new(like_params)
+    @like.user = current_user
 
     respond_to do |format|
       if @like.save
@@ -54,11 +55,18 @@ class LikesController < ApplicationController
   # DELETE /likes/1
   # DELETE /likes/1.json
   def destroy
-    @like.destroy
-    respond_to do |format|
-      format.html { redirect_to likes_url, notice: 'Like was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+	  if @like.user==current_user
+		  @like.destroy
+		  respond_to do |format|
+			  format.html { redirect_to likes_url, notice: 'Like was successfully destroyed.' }
+			  format.json { head :no_content }
+		  end
+	  else
+		  respond_to do |format|
+			  format.html { redirect_to ideas_url, notice: 'You can only destroy own likes' }
+			  format.json { head :no_content }
+		  end
+	  end
   end
 
   private
@@ -69,6 +77,6 @@ class LikesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def like_params
-      params.require(:like).permit(:like_type, :user_id, :idea_id)
+      params.require(:like).permit(:like_type, :idea_id)
     end
 end

--- a/app/views/likes/_form.html.erb
+++ b/app/views/likes/_form.html.erb
@@ -12,14 +12,6 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :like_type %><br>
-    <%= f.text_field :like_type %>
-  </div>
-  <div class="field">
-    <%= f.label :user_id %><br>
-    <%= f.text_field :user_id %>
-  </div>
-  <div class="field">
     <%= f.label :idea_id %><br>
     <%= f.text_field :idea_id %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :likes
+  resources :likes, only: [:create, :destroy]
   resources :tags
   resources :comments
   resources :ideas


### PR DESCRIPTION
Likes are created with user_id set to reference current_user and destruction is only allowed if current_user equals user of the like.