### PR TITLE
Js 3 35 time related stuff

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,10 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+class Application < Rails::Application
+  config.time_zone = 'Helsinki'
+end
+
 module Hydea
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe History, type: :model do
 
   it "is valid, has basket New and has time" do  	
   	expect(history_new).to be_valid
-  	expect(history_new.time).to eq("2016-07-04 00:00:00")
+  	expect(history_new.time).to eq("2016-07-04 00:00:00.000000000 +0300")
   end
 
   it "has user" do


### PR DESCRIPTION
-Time zone set to Helsinki in Rails application
-All data is still stored in DB with UTC time zone
-Checked that application returns correctly EEST +03:00 zone and that time is correctly displayed +02:00 (DST seems to be working automatically!)