### PR TITLE
Test if moderator title is displayed

### DIFF
--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -21,9 +21,7 @@
       <label class="checkbox-inline"><input type="checkbox" value="">
       <%= menutag.text %>
       </label>
-      <% if menutag == Tag.find(4)%>
-        <br>
-      <% end %>
+      <!-- When all University tags are displayed, new line should be added -->
     <% end %>
   </div>
   <!-- End tags -->

--- a/spec/views/index.html.erb_spec.rb
+++ b/spec/views/index.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = :should}
+end
+
+describe "ideas/index.html.erb", type: :view do
+  before do
+    idea = FactoryGirl.create(:idea)
+    user = FactoryGirl.create(:user, name: "Testi Tauno", moderator: true, title: "moderator")
+    FactoryGirl.create(:comment, user: user, text: "comment text", idea_id: 1)
+    user = FactoryGirl.create(:user, name: "Testi Tauno", moderator: false, title: "not moderator")
+    FactoryGirl.create(:comment, user: user, text: "comment text", idea_id: 1)
+    @ideas = Idea.all
+    render
+  end
+
+  it "displays moderator title" do
+    rendered.should match('(moderator)')
+  end
+
+  it "doesn't display non-moderator title" do
+    rendered.should_not match('(not moderator)')
+  end
+
+end


### PR DESCRIPTION
- Ideasin indexin tagien listaus pitäisi muuttaa jotenkin toimivammaksi

- Testi luo idean
- Testi luo moderaattorin
- Moderaattori luo kommentin
- Testi luo ei-moderaattorin tittelillä
- Ei-moderaattori luo kommentin
- displays moderator title tarkastaa onko HTML:n piirretty moderaattorin title
- doesn't display non-moderator title tarkistaa, ettei ei-moderaattorille piirretä titleä HTML:n
