### PR TITLE
Make listing ideas structured better

### DIFF
--- a/app/views/layouts/_list_ideas.html.erb
+++ b/app/views/layouts/_list_ideas.html.erb
@@ -5,147 +5,155 @@
 <% else %>
   <%@ideas.each do |idea|%>
     <div class="container">
-      <div class="panel-group">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <div class="row">
-              <!-- Draw topic -->
-              <div class="col-sm-9">
-                <h4 class="panel-title">
-                  <a data-toggle="collapse" href="#collapse<%= idea.id * 2 %>"><%= idea.topic %></a>
-                </h4>
-                <p><%= link_to User.find(idea.histories.first.user_id).name, User.find(idea.histories.first.user_id) %> - <%= idea.histories.first.created_at.strftime('%d.%m.%Y %H:%M ') %></p>
-                <%if idea.tags.empty?
-                  else%>
-                    <p>Tags:
-                    <% idea.tags.each do |tag| %>
-                      <%= tag.text %>
-                      <% if tag == idea.tags.last%>
-                      <% else%>
-                      ,
-                      <%end%>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="row">
+            <!-- Draw topic -->
+            <div class="col-sm-9">
+              <h4 class="panel-title">
+                <a data-toggle="collapse" href="#collapse<%= idea.id * 2 %>"><%= idea.topic %></a>
+              </h4>
+              <p><%= link_to User.find(idea.histories.first.user_id).name, User.find(idea.histories.first.user_id) %> - <%= idea.histories.first.time.strftime('%d.%m.%Y %H:%M ') %></p>
+              <%if idea.tags.empty?
+                else%>
+                  <p>Tags:
+                  <% idea.tags.each do |tag| %>
+                    <%= tag.text %>
+                    <% if tag == idea.tags.last%>
+                    <% else%>
+                    ,
                     <%end%>
-                  </p>
-                <%end%>
-              </div>
-              <!-- End topic -->
-              <!-- Draw likes and basket controls-->
-              <div class="<col-sm-3 center">
-                <% if not session[:user_id].nil? and current_user.moderator %>
-                  <% if idea.histories.last.basket == "New"%>
-                    <div class="btn-group">
-                      <%= link_to "Publish", publish_idea_path(idea), method: :post, class: "btn btn-primary" %>
-                      <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                        <span class="caret"></span>
-                      </button>
-                      <ul class="dropdown-menu" role="menu">
-                        <li>
-                          <%= link_to "Reject", reject_idea_path(idea), method: :post%>
-                        </li>
-                      </ul>
-                    </div>
-                  <% elsif idea.histories.last.basket == "Approved" or idea.histories.last.basket == "Changing" %>
-                    <div class="btn-group">
-                      <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                        Move to <span class="caret"></span>
-                      </button>
-                      <ul class="dropdown-menu" role="menu">
-                        <% if idea.histories.last.basket == "Approved" %>
-                        <li>
-                          <%= link_to "Changing", changing_idea_path(idea), method: :post%>
-                        </li>
-                        <% end %>
-                        <li>
-                          <%= link_to "Changed", changed_idea_path(idea), method: :post%>
-                        </li>
-                        <li>
-                          <%= link_to "Not Changed", not_changed_idea_path(idea), method: :post%>
-                        </li>
-                      </ul>
-                    </div>
-                  <% end %>
-                <% end %>
-                <% if not (idea.histories.last.basket == "New" or idea.histories.last.basket == "Rejected")%>
-                  <button type="button" class="btn btn-success btn-md"><span class="glyphicon glyphicon-thumbs-up"></span>
-                    <%= idea.likes.length %>
-                  </button>
-                <% end %>
-              </div>
-              <!-- End likes and basket controls-->
+                  <%end%>
+                </p>
+              <%end%>
             </div>
-          </div>
-          <div id="collapse<%= idea.id * 2 %>" class="panel-collapse collapse">
-            <!-- Show idea text -->
-            <div class="panel-body">
-              <div class="row">
-                <div class="col-sm-9">
-                  <p><%= idea.text %></p>
-                </div>
-                <div class="col-sm-3 histories">
-                  <% idea.histories.each do |history|%>
-                    <p><strong><%=history.basket%>:</strong><br>
-                    <%= history.created_at.strftime('%d.%m.%Y %H:%M ') %></p>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-            <!-- End idea text -->
-            <div class="panel-footer">
-              <div class="panel-group">
-                <div class="panel panel-default">
-                  <!-- Draw how many comments -->
-                  <div class="panel-heading">
-                    <h4 class="panel-title">
-                      <a data-toggle="collapse" href="#collapse<%= idea.id * 2 +1 %>">Comments (<%= idea.comments.count %>)</a>
-                    </h4>
+            <!-- End topic -->
+            <!-- Draw likes and basket controls-->
+            <div class="<col-sm-3 center">
+              <% if not session[:user_id].nil? and current_user.moderator %>
+                <% if idea.histories.last.basket == "New"%>
+                  <div class="btn-group">
+                    <%= link_to "Publish", publish_idea_path(idea), method: :post, class: "btn btn-primary" %>
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                      <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu">
+                      <li>
+                        <%= link_to "Reject", reject_idea_path(idea), method: :post%>
+                      </li>
+                    </ul>
                   </div>
-                  <!-- End how many comments -->
-                  <div id="collapse<%= idea.id * 2 + 1 %>" class="panel-collapse collapse">
-                    <% idea.comments.each do |comment| %>
-                      <!-- Draw comments -->
-                      <div class="panel-body">
-                        <% if not session[:user_id].nil? and current_user.moderator %>
-                          <%= link_to 'Delete', comment, method: :delete, data: { confirm: 'Are you sure?' }, :class => "btn-sm btn-danger delete_comment" %>
-                        <% end %>
-                        <p><%= link_to comment.user.name, comment.user_id %>
-                        <% if not comment.user.title.empty? and comment.user.moderator %>
-                          (<%= comment.user.title %>)
-                        <% end %>
-                        - <%= comment.time.strftime('%d.%m.%Y %H:%M ') %></p>
-                        <div class="panel-footer">
+                <% elsif idea.histories.last.basket == "Approved" or idea.histories.last.basket == "Changing" %>
+                  <div class="btn-group">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                      Move to <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu">
+                      <% if idea.histories.last.basket == "Approved" %>
+                      <li>
+                        <%= link_to "Changing", changing_idea_path(idea), method: :post%>
+                      </li>
+                      <% end %>
+                      <li>
+                        <%= link_to "Changed", changed_idea_path(idea), method: :post%>
+                      </li>
+                      <li>
+                        <%= link_to "Not Changed", not_changed_idea_path(idea), method: :post%>
+                      </li>
+                    </ul>
+                  </div>
+                <% end %>
+              <% end %>
+              <% if not (idea.histories.last.basket == "New" or idea.histories.last.basket == "Rejected")%>
+                <button type="button" class="btn btn-success btn-md"><span class="glyphicon glyphicon-thumbs-up"></span>
+                  <%= idea.likes.length %>
+                </button>
+              <% end %>
+            </div>
+            <!-- End likes and basket controls-->
+          </div>
+        </div>
+        <div id="collapse<%= idea.id * 2 %>" class="panel-collapse collapse">
+          <div class="panel-body">
+            <div class="row">
+              <!-- Show idea text -->
+              <div class="col-sm-9">
+                <p><%= idea.text %></p>
+              </div>
+              <!-- End idea text -->
+              <div class="col-sm-3 histories">
+                <% idea.histories.each do |history|%>
+                  <p><strong><%=history.basket%>:</strong><br>
+                  <%= history.time.strftime('%d.%m.%Y %H:%M ') %></p>
+                <% end %>
+              </div>
+            </div>
+            <div class="panel panel-default">
+              <!-- Draw how many comments -->
+              <div class="panel-heading">
+                <h4 class="panel-title">
+                  <a data-toggle="collapse" href="#collapse<%= idea.id * 2 +1 %>">Comments (<%= idea.comments.count %>)</a>
+                </h4>
+              </div>
+              <!-- End how many comments -->
+              <div id="collapse<%= idea.id * 2 + 1 %>" class="panel-collapse collapse">
+                <!-- Draw comments -->
+                <% idea.comments.each do |comment| %>
+                  <ul class="list-group">
+                    <li class="list-group-item">
+                      <div class="panel panel-default">
+                        <div class="panel-heading">
+                          <% if not session[:user_id].nil? and current_user.moderator %>
+                            <%= link_to 'Delete', comment, method: :delete, data: { confirm: 'Are you sure?' }, :class => "btn-sm btn-danger delete_comment" %>
+                          <% end %>
+                          <p>
+                          <%= link_to comment.user.name, comment.user_id %>
+                          <% if not comment.user.title.empty? and comment.user.moderator %>
+                            (<%= comment.user.title %>)
+                          <% end %>
+                          - <%= comment.time.strftime('%d.%m.%Y %H:%M ') %>
+                          </p>
+                        </div>
+                        <div class="panel-body">
                           <p><%= comment.text %></p>
                         </div>
                       </div>
-                      <!-- End draw comments -->
-                    <% end %>
-                    <!-- If user is logged in show comment box -->
-                    <% if not session[:user_id].nil? %>
-                    <%= form_for("comment", :url => main_app.comments_path, :html => { :class => "form-horizontal" } ) do |f| %>
-                    <%= f.hidden_field :idea_id, :value => idea.id %>
-                    <%= f.hidden_field :time, :value => Time.now %>
-                    <div class="panel-body">
-                      <div class="panel-footer">
-                        <div class="form-group" method="post" action="comment/new">
-                        <label for="comment">Comment:</label>
-                        <%= f.text_area :text,class: "form-control", rows: "5", id: "comment"%>
-                        <button type="submit" class="btn btn-primary">Send </button>
-                        <% end %>
+                    </li>
+                  <% end %>
+                  <!-- End draw comments -->
+                  <!-- If user is logged in show comment box -->
+                  <% if not session[:user_id].nil? %>
+                    <li class="list-group-item">
+                      <%= form_for("comment", :url => main_app.comments_path, :html => { :class => "form-horizontal" } ) do |f| %>
+                      <%= f.hidden_field :idea_id, :value => idea.id %>
+                      <%= f.hidden_field :time, :value => Time.now %>
+                      <div method="post" action="comment/new">
+                        <div class="panel panel-default">
+                          <div class="panel-heading">
+                            <label for="comment">Comment:</label>
+                          </div>
+                          <div class="panel-body">
+                            <%= f.text_area :text,class: "form-control", rows: "5", id: "comment"%>
+                            <button type="submit" class="btn btn-primary">Send </button>
+                            <% end %>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                    <% end %>
-                    <!-- End comment box -->
-                  </div>
-                </div>
-              </div>
-              <div class="center">
-                <a data-toggle="collapse" href="#collapse<%= idea.id * 2 %>">
-                  <span class="glyphicon glyphicon-menu-up"></span>
-                </a>
+                    </li>
+                  <% end %>
+                  <!-- End comment box -->
+                </ul>
               </div>
             </div>
           </div>
         </div>
+        <!-- Add collapse functionality -->
+        <div class="panel-footer center">
+          <a data-toggle="collapse" href="#collapse<%= idea.id * 2 %>">
+            <span class="glyphicon glyphicon-option-horizontal"></span>
+          </a>
+        </div>
+        <!-- End collapse functionality -->
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Tämä piirtää avatun idean paljon paremmin ja kommenttien tulostuminen on paljon nätimpi. Lisäksi jokaisen idean loppuun piirtyy kahva, johon voi lisätä toiminnallisuuksia kuten avatun idean pienentämisen ja JavaScriptillä idean titleen siirtymisen.

Tätä ei varmaan kannata enään tänään alkaa mergettelemään masteriin, koska parempi, että buildi varmasti toimii huomenna.